### PR TITLE
[# 116497533] As the pipeline architect, so it's easy for developers, data scientists, and product managers to understand how we write new PySpark programs into running pipelines, write an example that works easily in command line mode and which can be submitted as a …

### DIFF
--- a/lib/ruote-kit/views/expression.html.haml
+++ b/lib/ruote-kit/views/expression.html.haml
@@ -96,6 +96,14 @@
         - if workitem = @process.stored_workitems.find { |wi| wi.fei == @expression.fei }
           GET
           = alink(:workitems, @expression.fei.sid)
+    %tr
+      %td
+        stash
+      %td
+        - stash = @expression.h.stash
+        - stash = Rufus::Json.pretty_encode(stash)
+        - rows = stash.split("\n").size
+        %textarea#tree{ :name => 'stash', :cols => 70, :rows => rows } #{stash}
 
     %tr
       %td.no_border{ :colspan => 2 }


### PR DESCRIPTION
Display an expression's `stash` in the expression page.  The `stash` is something a participant can `put` to *before* replying (e.g., to save state from `on_workitem`), but was not previously visible. Since we have been unable to set pipeline IDs to our own strings and still log the outputs of our Amazon Data Pipelines, we need to be able to see them somewhere.